### PR TITLE
Sprint2 77 bug events

### DIFF
--- a/src/database/customerdatabase.cpp
+++ b/src/database/customerdatabase.cpp
@@ -77,7 +77,6 @@ QStandardItemModel* CustomerDatabase::getCustomersTree(QString filter)
 
     QSqlQuery q;
 
-
     q.prepare("SELECT * "
               "FROM Customer WHERE 1 "+filter+" "
               "ORDER BY UPPER(company), UPPER(lastnameReferent)");
@@ -90,14 +89,22 @@ QStandardItemModel* CustomerDatabase::getCustomersTree(QString filter)
             1.1);
     }
 
-    QStandardItem* item;
-
-    item = new QStandardItem("Tous les clients");
+    QStandardItem* item = new QStandardItem("Tous les clients");
     item->setIcon(QIcon(":icons/customer"));
     retour->appendRow(item);
 
     while(q.next()) {
         QStandardItem* item;
+
+        if(value(q,"company").toString().isEmpty())
+            item = new QStandardItem(value(q, "lastnameReferent").toString().toUpper()+" "+
+                                     Utils::firstLetterToUpper(value(q,"firstnameReferent").toString()));
+        else
+            item = new QStandardItem(Utils::firstLetterToUpper(value(q,"company").toString()));
+
+        item->setIcon(QIcon(":icons/customer"));
+
+        // Project for a customer
         QSqlQuery q2;
 
         q2.prepare("SELECT *"
@@ -113,20 +120,11 @@ QStandardItemModel* CustomerDatabase::getCustomersTree(QString filter)
                 1.1);
         }
 
-        if(value(q,"company").toString().isEmpty())
-            item = new QStandardItem(value(q, "lastnameReferent").toString().toUpper()+" "+
-                                     Utils::firstLetterToUpper(value(q,"firstnameReferent").toString()));
-        else
-            item = new QStandardItem(Utils::firstLetterToUpper(value(q,"company").toString()));
-
-
-         while(q2.next()) {
+        while(q2.next()) {
             QStandardItem *child = new QStandardItem(value(q2,"name").toString());
             child->setIcon(QIcon(":icons/img/project"));
             item->appendRow(child);
-         }
-
-        item->setIcon(QIcon(":icons/customer"));
+        }
 
         retour->appendRow(item);
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -253,8 +253,8 @@ void MainWindow::updateTree(QString filter)
 
 void MainWindow::newProject()
 {
-    qDebug() << "ok";
     QModelIndex index = ui->tblCustomers->currentIndex();
+
     AddProjectDialog *w = new AddProjectDialog();
     if (ui->tblCustomers->selectionModel()->hasSelection()) {
         w = new AddProjectDialog(index.row(), 0, 0);
@@ -387,6 +387,7 @@ void MainWindow::changeProjectsTable()
     ui->tblProjects->setColumnWidth(2, 200);
     ui->tblProjects->setColumnWidth(3, 122);
     ui->tblProjects->setColumnWidth(4, 122);
+    ui->stackedWidget->setCurrentIndex(1);
 }
 
 void MainWindow::backToCustomersTable()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -49,7 +49,7 @@ void MainWindow::demo() {
 
 int MainWindow::getCurrentTableId(QTableView *tbl) {
     QModelIndex idCell = tbl->model()->index(tbl->currentIndex().row(), 0);
-    return tbl->model()->itemData(idCell).value(0).toInt();
+        return tbl->model()->itemData(idCell).value(0).toInt();
 }
 
 int MainWindow::getCurrentCustomerId() {
@@ -363,6 +363,10 @@ void MainWindow::changeTree()
     }
 
     if (isProjectItemTree()) {
+        // Need to verify if the current customer is the father
+        // Then update TableProjects
+        ui->tblCustomers->selectRow(index.parent().row()-1);
+        updateTableProjects(getCurrentCustomerId());
         ui->tblProjects->selectRow(idRow);
         updateTableBillings(getCurrentProjectId());
         ui->stackedWidget->setCurrentIndex(2);
@@ -398,26 +402,6 @@ void MainWindow::backToCustomersTable()
 void MainWindow::backToProjectsTable()
 {
     ui->stackedWidget->setCurrentIndex(1);
-}
-
-void MainWindow::projectsCustomersTableTree()
-{
-
-    /*QModelIndex index = ui->trCustomers->selectionModel()->currentIndex();
-
-    if (index.data(Qt::DisplayRole).toString() == "Tous les clients")
-        ui->stackedWidget->setCurrentIndex(0);
-    else if(isCustomer()) { //si client
-        ui->stackedWidget->setCurrentIndex(1);
-        changeProjectsTable();
-        ui->trCustomers->collapseAll();
-        ui->trCustomers->expand(index);
-    }
-    else { //si projet
-        ui->tblProjects->selectRow(index.row());
-        ui->stackedWidget->setCurrentIndex(2);
-        updateTableBillings(getCurrentProjectId());
-    */
 }
 
 void MainWindow::quotesProject()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -81,6 +81,19 @@ bool MainWindow::isCustomer()
     return index.model()->hasChildren(index);
 }
 
+bool MainWindow::isTreeRoot() {
+    return ui->trCustomers->currentIndex().data() == "Tous les clients";
+}
+bool MainWindow::isProjectItemTree() {
+    return false;
+}
+bool MainWindow::isCustomerItemTree() {
+    return !isTreeRoot() && !ui->trCustomers->currentIndex().parent().isValid();
+}
+bool MainWindow::isQuoteItemTree() {
+    return false;
+}
+
 void MainWindow::addCustomer()
 {
     DialogAddCustomer win;
@@ -331,12 +344,27 @@ void MainWindow::aboutIcons()
 
 void MainWindow::changeTree()
 {
-    QModelIndex index =
-            ui->trCustomers->model()->index(ui->trCustomers->currentIndex().row(), 0);
-    //emit changeCustomerTree(index);
-    ui->tblCustomers->selectRow(index.row()-1);
+    QModelIndex index = ui->trCustomers->currentIndex();
+    int idRow = ui->trCustomers->currentIndex().row();
     int id = getCurrentCustomerId();
-    ui->wdgCustomerData->printInformations(id);
+    //QModelIndex a = ui->trCustomers->model()->index(1,0, QModelIndex);
+    //Customer custom(index.data());
+
+
+    qDebug() << "Row : " << idRow << "\tCustomer id : " << id << " " << index.data().toString() << " " << isTreeRoot();
+
+    //qDebug() << "";
+    if (isTreeRoot()) {
+        qDebug() << "Clear";
+        ui->tblCustomers->clearSelection();
+        ui->wdgCustomerData->hide();
+    }
+
+    if (isCustomerItemTree()) {
+        qDebug() << "Customer" << id << " " << idRow;
+        ui->tblCustomers->selectRow(idRow-1);
+        ui->wdgCustomerData->printInformations(id);
+    }
 }
 
 void MainWindow::changeCustomerTable()
@@ -387,7 +415,7 @@ void MainWindow::projectsCustomersTableTree()
         ui->tblProjects->selectRow(index.row());
         ui->stackedWidget->setCurrentIndex(2);
         updateTableBillings(getCurrentProjectId());
-    }*/
+    */
 }
 
 void MainWindow::quotesProject()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -70,28 +70,8 @@ QString MainWindow::getCurrentCustomerName()
 
 QString MainWindow::getCurrentProjectName()
 {
-    QModelIndex index =
-            ui->tblProjects->model()->index(ui->tblProjects->currentIndex().row(),1);
-    return index.model()->itemData(index).value(0).toString();
-}
-
-bool MainWindow::isCustomer()
-{
-    QModelIndex index = ui->trCustomers->selectionModel()->currentIndex();
-    return index.model()->hasChildren(index);
-}
-
-bool MainWindow::isTreeRoot() {
-    return ui->trCustomers->currentIndex().data() == "Tous les clients";
-}
-bool MainWindow::isProjectItemTree() {
-    return false;
-}
-bool MainWindow::isCustomerItemTree() {
-    return !isTreeRoot() && !ui->trCustomers->currentIndex().parent().isValid();
-}
-bool MainWindow::isQuoteItemTree() {
-    return false;
+    QModelIndex index = ui->tblProjects->currentIndex();
+    return index.data().toString();
 }
 
 void MainWindow::addCustomer()
@@ -102,7 +82,6 @@ void MainWindow::addCustomer()
         updateTree();
     }
 }
-
 
 void MainWindow::editCustomer() {
     if (ui->tblCustomers->selectionModel()->hasSelection()) {
@@ -116,6 +95,8 @@ void MainWindow::editCustomer() {
 
 void MainWindow::removeCustomer() {
     removeItem(ui->tblCustomers, ItemType(ItemType::CUSTOMER, "client"));
+    ui->trCustomers->setCurrentIndex(ui->trCustomers->indexAt(QPoint()));
+    changeTree();
 }
 
 void MainWindow::updateUser()
@@ -140,13 +121,11 @@ void MainWindow::removeItem(QTableView *tbl, ItemType itemType)
             int pid = tbl->model()->data(ls,Qt::DisplayRole).toInt();
             itemType.getModel(pid)->remove();
             updateTableCustomers();
-            updateTree();
             updateTableProjects();
+            updateTree();
         }
     }
 }
-
-
 
 void MainWindow::updateTableBillings(const int idProject)
 {
@@ -159,7 +138,6 @@ void MainWindow::updateTableBillings(const int idProject)
     ui->tblQuotes->setColumnWidth(2, 100);
     ui->tblQuotes->setColumnWidth(4, 150);
 }
-
 
 void MainWindow::addQuote()
 {
@@ -174,14 +152,13 @@ void MainWindow::addQuote()
     }
 }
 
-
-
 void MainWindow::editUser()
 {
     UserDataDialog userdialog;
     userdialog.exec();
     updateUser();
 }
+
 void MainWindow::search() {
     emit search(ui->leSearch->text());
 }
@@ -231,6 +208,7 @@ void MainWindow::openContextualMenuTable(const QPoint point)
     buffPoint.setY(point.y()+35);
     menu->exec(ui->tblCustomers->mapToGlobal(buffPoint));
 }
+
 void MainWindow::openContextualMenuTree(const QPoint point)
 {
     QMenu* menu = new CustomerContextualMenu(this);
@@ -262,7 +240,6 @@ void MainWindow::updateTableProjects(const int pId)
     if(pId != 0) {
         lastId = pId;
     }
-    qDebug() << lastId;
     ui->tblProjects->setModel(ProjectDatabase::instance()->getProjectsTable(lastId));
     ui->tblProjects->hideColumn(0);
 }
@@ -276,6 +253,7 @@ void MainWindow::updateTree(QString filter)
 
 void MainWindow::newProject()
 {
+    qDebug() << "ok";
     QModelIndex index = ui->tblCustomers->currentIndex();
     AddProjectDialog *w = new AddProjectDialog();
     if (ui->tblCustomers->selectionModel()->hasSelection()) {
@@ -287,7 +265,6 @@ void MainWindow::newProject()
     }
     updateTree("");
 }
-
 
 void MainWindow::removeProject() {
     removeItem(ui->tblProjects, ItemType(ItemType::PROJECT, "projet"));
@@ -342,46 +319,74 @@ void MainWindow::aboutIcons()
                  "l'usage du logiciel FactDev");
 }
 
+bool MainWindow::isTreeRoot() {
+    return ui->trCustomers->currentIndex().data() == "Tous les clients";
+}
+
+bool MainWindow::isProjectItemTree() {
+    int i = 0;
+    QModelIndex currentIndex = ui->trCustomers->currentIndex();
+    while (currentIndex.parent().isValid()) {
+        currentIndex = currentIndex.parent();
+        i++;
+    }
+    return i == 1;
+}
+
+bool MainWindow::isCustomerItemTree() {
+    return !isTreeRoot() && !ui->trCustomers->currentIndex().parent().isValid();
+}
+
+bool MainWindow::isQuoteItemTree() {
+    return false;
+}
+
 void MainWindow::changeTree()
 {
     QModelIndex index = ui->trCustomers->currentIndex();
-    int idRow = ui->trCustomers->currentIndex().row();
-    int id = getCurrentCustomerId();
-
-    //qDebug() << "Row : " << idRow << "\tCustomer id : " << id << " " << index.data().toString() << " " << isTreeRoot();
+    int idRow = index.row();
 
     if (isTreeRoot()) {
-        qDebug() << "Clear";
+        ui->stackedWidget->setCurrentIndex(0);
         ui->tblCustomers->clearSelection();
         ui->wdgCustomerData->hide();
+        ui->trCustomers->collapseAll();
     }
 
     if (isCustomerItemTree()) {
-        qDebug() << "Customer" << id << " " << idRow;
         ui->tblCustomers->selectRow(idRow-1);
-        ui->wdgCustomerData->printInformations(id);
+        ui->wdgCustomerData->printInformations(getCurrentCustomerId());
+        ui->trCustomers->collapseAll();
+        ui->trCustomers->expand(index);
+        changeProjectsTable();
+        ui->stackedWidget->setCurrentIndex(1);
+    }
+
+    if (isProjectItemTree()) {
+        ui->tblProjects->selectRow(idRow);
+        updateTableBillings(getCurrentProjectId());
+        ui->stackedWidget->setCurrentIndex(2);
+    }
+
+    if (isQuoteItemTree()) { // Quote or billing, to define
+        //TODO
     }
 }
 
 void MainWindow::changeCustomerTable()
 {
-    //QModelIndex index = ui->tblCustomers->model()->index(ui->tblCustomers->currentIndex().row(), 0);
-    int id = getCurrentCustomerId();
-    ui->wdgCustomerData->printInformations(id);
+    ui->wdgCustomerData->printInformations(getCurrentCustomerId());
 }
 
 void MainWindow::changeProjectsTable()
 {
-    int id = getCurrentCustomerId();
-    updateTableProjects(id);
+    updateTableProjects(getCurrentCustomerId());
     ui->lblProjects->setText("<b>Projet(s) de: " + getCurrentCustomerName()+"</b>");
-    ui->tblProjects->hideColumn(0);
     ui->tblProjects->setColumnWidth(0, 100);
     ui->tblProjects->setColumnWidth(1, 150);
     ui->tblProjects->setColumnWidth(2, 200);
-    ui->tblProjects->setColumnWidth(3, 125);
-    ui->tblProjects->setColumnWidth(4, 125);
-    ui->stackedWidget->setCurrentIndex(1);
+    ui->tblProjects->setColumnWidth(3, 122);
+    ui->tblProjects->setColumnWidth(4, 122);
 }
 
 void MainWindow::backToCustomersTable()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -347,13 +347,9 @@ void MainWindow::changeTree()
     QModelIndex index = ui->trCustomers->currentIndex();
     int idRow = ui->trCustomers->currentIndex().row();
     int id = getCurrentCustomerId();
-    //QModelIndex a = ui->trCustomers->model()->index(1,0, QModelIndex);
-    //Customer custom(index.data());
 
+    //qDebug() << "Row : " << idRow << "\tCustomer id : " << id << " " << index.data().toString() << " " << isTreeRoot();
 
-    qDebug() << "Row : " << idRow << "\tCustomer id : " << id << " " << index.data().toString() << " " << isTreeRoot();
-
-    //qDebug() << "";
     if (isTreeRoot()) {
         qDebug() << "Clear";
         ui->tblCustomers->clearSelection();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -147,12 +147,6 @@ void MainWindow::updateTableBillings(const int idProject)
     ui->tblQuotes->setColumnWidth(4, 150);
 }
 
-void MainWindow::openCustomer()
-{
-    int id = getCurrentCustomerId();
-    ui->wdgCustomerData->printInformations(id);
-}
-
 
 void MainWindow::addQuote()
 {
@@ -228,7 +222,7 @@ void MainWindow::openContextualMenuTree(const QPoint point)
 {
     QMenu* menu = new CustomerContextualMenu(this);
 
-    emit changeCustomerTree();
+    emit changeTree();
     QPoint buffPoint = point;
     buffPoint.setX(point.x()+35);
     buffPoint.setY(point.y()+35);
@@ -335,31 +329,21 @@ void MainWindow::aboutIcons()
                  "l'usage du logiciel FactDev");
 }
 
-void MainWindow::changeCustomerTree(QModelIndex index)
-{
-    ui->tblCustomers->selectRow(index.row()-1);     // Séléction de la ligne correspondante au client sélectionné
-    emit openCustomer();
-}
-
-void MainWindow::changeCustomerTree()
+void MainWindow::changeTree()
 {
     QModelIndex index =
             ui->trCustomers->model()->index(ui->trCustomers->currentIndex().row(), 0);
-    emit changeCustomerTree(index);
-}
-
-void MainWindow::changeCustomerTable(QModelIndex index)
-{
-    // Gérer le rafraichissement des vues lors d'un changement d'état dans la séléction des clients
-    // ui->trCustomers->set(index.row()+1);
-    emit openCustomer();
+    //emit changeCustomerTree(index);
+    ui->tblCustomers->selectRow(index.row()-1);
+    int id = getCurrentCustomerId();
+    ui->wdgCustomerData->printInformations(id);
 }
 
 void MainWindow::changeCustomerTable()
 {
-    QModelIndex index =
-            ui->tblCustomers->model()->index(ui->tblCustomers->currentIndex().row(), 0);
-    emit changeCustomerTable(index);
+    //QModelIndex index = ui->tblCustomers->model()->index(ui->tblCustomers->currentIndex().row(), 0);
+    int id = getCurrentCustomerId();
+    ui->wdgCustomerData->printInformations(id);
 }
 
 void MainWindow::changeProjectsTable()
@@ -389,7 +373,7 @@ void MainWindow::backToProjectsTable()
 void MainWindow::projectsCustomersTableTree()
 {
 
-    QModelIndex index = ui->trCustomers->selectionModel()->currentIndex();
+    /*QModelIndex index = ui->trCustomers->selectionModel()->currentIndex();
 
     if (index.data(Qt::DisplayRole).toString() == "Tous les clients")
         ui->stackedWidget->setCurrentIndex(0);
@@ -403,7 +387,7 @@ void MainWindow::projectsCustomersTableTree()
         ui->tblProjects->selectRow(index.row());
         ui->stackedWidget->setCurrentIndex(2);
         updateTableBillings(getCurrentProjectId());
-    }
+    }*/
 }
 
 void MainWindow::quotesProject()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -75,11 +75,6 @@ public slots:
      */
     void removeCustomer();
     /**
-     * @brief MainWindow::openCustomer open a customer and print his informations
-     * @see CustomerDataWidget
-     */
-    void openCustomer();
-    /**
      * @brief MainWindow::editUser modify the user
      * @see UserDataDialog
      */
@@ -147,21 +142,9 @@ private slots:
      */
     void openContextualMenuTree(const QPoint point);
     /**
-     * @brief MainWindow::changeCustomerTree when customer changed in tree
-     * update customer selected in table and his informations
-     * @param index index of selected customer
-     */
-    void changeCustomerTree(QModelIndex index);
-    /**
      * @brief MainWindow::changeCustomerTree call changeCustomerTree
      */
-    void changeCustomerTree();
-    /**
-     * @brief MainWindow::changeCustomerTable when customer changed in table
-     * update his informations
-     * @param index index of selected customer
-     */
-    void changeCustomerTable(QModelIndex index);
+    void changeTree();
     /**
      * @brief MainWindow::changeCustomerTable calls changeCustomerTable
      */

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -172,11 +172,6 @@ private slots:
      */
     void backToProjectsTable();
     /**
-     * @brief MainWindow::projectsCustomersTableTree displays projects of a customer
-     * or all customers
-     */
-    void projectsCustomersTableTree();
-    /**
      * @brief MainWindow::quotesProject displays quotes of a project with the <i>index</i>
      * of the project in the table of projects
      */

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -29,7 +29,6 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
-
     /**
      * @brief MainWindow::getCurrentCustomerId get the selected customer
      * @return id of the selected customer
@@ -54,17 +53,26 @@ public:
      */
     QString getCurrentProjectName();
     /**
-     * @brief MainWindow::isProject return if the node selected in the
-     * tree is a customer or a project
-     * @return true if it's a customer, false if it's a project
+     * @brief MainWindow::isTreeRoot return if the node selected in the
+     * tree is the root
+     * @return boolean
      */
-    bool isCustomer();
-
     bool isTreeRoot();
-    bool isProjectItemTree();
+    /**
+     * @brief MainWindow::isCustomerItemTree return if the node selected in the
+     * tree is a customer
+     * @return boolean
+     */
     bool isCustomerItemTree();
-    bool isQuoteItemTree();
+    /**
+     * @brief MainWindow::isProjectItemTree return if the node selected in the
+     * tree is a project
+     * @return boolean
+     */
+    bool isProjectItemTree();
 
+    //TODO
+    bool isQuoteItemTree();
     void demo();
 public slots:
     /**
@@ -81,16 +89,14 @@ public slots:
      */
     void removeCustomer();
     /**
-     * @brief MainWindow::editUser modify the user
-     * @see UserDataDialog
-     */
-
-    /**
      * @brief MainWindow::addQuote open window to add a new quote
      * @see AddQuoteDialog
      */
     void addQuote();
-
+    /**
+     * @brief MainWindow::editUser modify the user
+     * @see UserDataDialog
+     */
     void editUser();
     /**
      * @brief MainWindow::search launch a new search
@@ -105,18 +111,15 @@ public slots:
      * @brief MainWindow::newProject Create a new project for a customer
      * @see AddProjectDialog
      */
-    void newProject(void);
-
+    void newProject();
     /**
      * @brief MainWindow::removeProject Remove a project for a customer
      */
     void removeProject(void);
-
     /**
      * @brief MainWindow::editProject Modify the customer project
      */
     void editProject(void);
-
     /**
      * @brief MainWindow::aboutQt show Qt's details
      */
@@ -195,7 +198,6 @@ private:
      * (just client in the first version)
      */
     void updateTree(QString filter="");
-
     /**
      * @brief MainWindow::updateUser Update user data panel
      */
@@ -206,7 +208,6 @@ private:
      * @param idProject Only billings corresponding to the idProject
      */
     void updateTableBillings(const int idProject);
-
     /**
      * @brief MainWindow::removeItem Remove the <i>item</i> selected in the
      * table <i>tbl</i>
@@ -214,7 +215,6 @@ private:
      * @param item an item in the table <i>tbl</i>
      */
     void removeItem(QTableView* tbl, ItemType item);
-
     /**
      * @brief MainWindow::getCurrentTableId Get the ID of the item selected in
      * the  tableview <i>tbl</i>

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -59,6 +59,12 @@ public:
      * @return true if it's a customer, false if it's a project
      */
     bool isCustomer();
+
+    bool isTreeRoot();
+    bool isProjectItemTree();
+    bool isCustomerItemTree();
+    bool isQuoteItemTree();
+
     void demo();
 public slots:
     /**

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -18,7 +18,7 @@
     <item row="0" column="0">
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="page">
        <layout class="QGridLayout" name="gridLayout_3">
@@ -259,7 +259,7 @@
      <x>0</x>
      <y>0</y>
      <width>1237</width>
-     <height>27</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFichier">
@@ -651,8 +651,8 @@ border: 1px solid #bbb;</string>
    <slot>editCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>910</x>
-     <y>312</y>
+     <x>799</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
      <x>764</x>
@@ -667,8 +667,8 @@ border: 1px solid #bbb;</string>
    <slot>removeCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>801</x>
-     <y>312</y>
+     <x>671</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
      <x>280</x>
@@ -779,8 +779,8 @@ border: 1px solid #bbb;</string>
    <slot>addCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>527</x>
-     <y>312</y>
+     <x>357</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
      <x>406</x>
@@ -795,8 +795,8 @@ border: 1px solid #bbb;</string>
    <slot>newProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>681</x>
-     <y>312</y>
+     <x>513</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
      <x>720</x>
@@ -901,38 +901,6 @@ border: 1px solid #bbb;</string>
    </hints>
   </connection>
   <connection>
-   <sender>tblCustomers</sender>
-   <signal>clicked(QModelIndex)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>changeCustomerTable(QModelIndex)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>668</x>
-     <y>194</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>302</x>
-     <y>386</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>trCustomers</sender>
-   <signal>clicked(QModelIndex)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>changeCustomerTree(QModelIndex)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>122</x>
-     <y>555</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>-206</x>
-     <y>364</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>actSettings</sender>
    <signal>triggered()</signal>
    <receiver>MainWindow</receiver>
@@ -950,29 +918,13 @@ border: 1px solid #bbb;</string>
   </connection>
   <connection>
    <sender>tblCustomers</sender>
-   <signal>clicked(QModelIndex)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>changeCustomerTable(QModelIndex)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>397</x>
-     <y>123</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>302</x>
-     <y>386</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>tblCustomers</sender>
    <signal>doubleClicked(QModelIndex)</signal>
    <receiver>MainWindow</receiver>
    <slot>changeProjectsTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>668</x>
-     <y>194</y>
+     <x>379</x>
+     <y>107</y>
     </hint>
     <hint type="destinationlabel">
      <x>1026</x>
@@ -987,8 +939,8 @@ border: 1px solid #bbb;</string>
    <slot>backToCustomersTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>463</x>
-     <y>139</y>
+     <x>472</x>
+     <y>133</y>
     </hint>
     <hint type="destinationlabel">
      <x>326</x>
@@ -1051,8 +1003,8 @@ border: 1px solid #bbb;</string>
    <slot>backToCustomersTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>379</x>
-     <y>116</y>
+     <x>330</x>
+     <y>111</y>
     </hint>
     <hint type="destinationlabel">
      <x>369</x>
@@ -1067,7 +1019,7 @@ border: 1px solid #bbb;</string>
    <slot>backToProjectsTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>500</x>
+     <x>505</x>
      <y>111</y>
     </hint>
     <hint type="destinationlabel">
@@ -1124,12 +1076,43 @@ border: 1px solid #bbb;</string>
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>trCustomers</sender>
+   <signal>clicked(QModelIndex)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>changeTree()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>221</x>
+     <y>393</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>292</x>
+     <y>347</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>tblCustomers</sender>
+   <signal>clicked(QModelIndex)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>changeCustomerTable()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>532</x>
+     <y>226</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>415</x>
+     <y>91</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>addCustomer()</slot>
   <slot>editCustomer()</slot>
   <slot>removeCustomer()</slot>
-  <slot>openCustomer()</slot>
   <slot>search(QString)</slot>
   <slot>search()</slot>
   <slot>editUser()</slot>
@@ -1138,9 +1121,7 @@ border: 1px solid #bbb;</string>
   <slot>aboutFact()</slot>
   <slot>aboutFactDev()</slot>
   <slot>aboutIcons()</slot>
-  <slot>changeCustomerTree(QModelIndex)</slot>
   <slot>changeCustomer()</slot>
-  <slot>changeCustomerTable(QModelIndex)</slot>
   <slot>openProjects()</slot>
   <slot>changeProjectsTable()</slot>
   <slot>backToCustomersTable()</slot>
@@ -1150,5 +1131,7 @@ border: 1px solid #bbb;</string>
   <slot>backToProjectsTable()</slot>
   <slot>editProject()</slot>
   <slot>removeProject()</slot>
+  <slot>changeCustomerTable()</slot>
+  <slot>changeTree()</slot>
  </slots>
 </ui>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -965,22 +965,6 @@ border: 1px solid #bbb;</string>
    </hints>
   </connection>
   <connection>
-   <sender>trCustomers</sender>
-   <signal>clicked(QModelIndex)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>projectsCustomersTableTree()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>161</x>
-     <y>499</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>300</x>
-     <y>637</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>tblProjects</sender>
    <signal>doubleClicked(QModelIndex)</signal>
    <receiver>MainWindow</receiver>

--- a/src/widgets/customercontextualmenu.cpp
+++ b/src/widgets/customercontextualmenu.cpp
@@ -28,7 +28,7 @@ CustomerContextualMenu::CustomerContextualMenu(QWidget* widget)  :QMenu(widget)
     addAction(_openAction);
     addAction(_editAction);
     addAction(_removeAction);
-    connect(_openAction, SIGNAL(triggered()), widget, SLOT(openCustomer()));
+    //connect(_openAction, SIGNAL(triggered()), widget, SLOT(openCustomer()));
     connect(_editAction, SIGNAL(triggered()), widget, SLOT(editCustomer()));
     connect(_removeAction, SIGNAL(triggered()), widget, SLOT(removeCustomer()));
 }


### PR DESCRIPTION
Les bugs à propos des événements sur l'arbre sont résolus.
Notamment celui ou on sélectionnait un projet sans cliquer sur l'utilisateur mais en cliquant sur la flèche, cela affichait la table des devis du mauvais client.
J'ai créé une méthode changeTree() ou tous les événements relatifs au clic sur l'arbre sont géré dedans et cette méthode se charge  de mettre à jour le(s) tableau(x) qui correspondent à l'élément sélectionné.
J'ai fait un refactoring et j'ai notamment supprimé la méthode de Tsoo qui était redondante changeProjectsTree ou qqch comme ça.

(J'ai eut un peu de mal à comprendre la méthode getCurrentTableId() peut être se serait bien de rajouter des commentaires sur cette méthode)