### PR TITLE
Sprint3/46 remove bill

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -26,6 +26,7 @@ MainWindow::MainWindow(QWidget *parent) :
         SLOT(openContextualMenuTree(const QPoint &)));
 
     updateUser();
+    updateBtn();
     demo();
 }
 
@@ -232,9 +233,6 @@ void MainWindow::updateTree(QString filter)
 {
     ui->trCustomers->setModel(
                 Databases::CustomerDatabase::instance()->getTree(filter));
-
-
-    ui->trCustomers->header()->close();
 }
 
 void MainWindow::newProject()
@@ -328,13 +326,18 @@ void MainWindow::changeTree()
     default:        // Other
         break;
     }
-
     updateBtn();
 }
 
 void MainWindow::changeCustomerTable()
 {
     ui->wdgCustomerData->printInformations(getCurrentCustomerId());
+    int row = ui->tblCustomers->currentIndex().row();
+    QModelIndex index(ui->trCustomers->indexAt(QPoint()));
+    for (int i = 0 ; i <= row ; ++i) {
+        index = ui->trCustomers->indexBelow(index);
+    }
+    ui->trCustomers->setCurrentIndex(index);
     updateBtn();
 }
 
@@ -379,6 +382,7 @@ void MainWindow::updateBtn()
     } else {
         ui->btnEdit->setEnabled(false);
         ui->btnDelCustomer->setEnabled(false);
+        ui->trCustomers->setCurrentIndex(ui->trCustomers->indexAt(QPoint()));
     }
 
     if (ui->tblProjects->currentIndex().row() > -1

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -398,17 +398,24 @@ void MainWindow::updateBtn()
         if (b.isBilling()) {
             ui->btnEditDoc->setText("Éditer la facture");
             ui->btnEditDoc->setIcon(QIcon(":icons/img/add_bill"));
+            ui->btnRemoveDoc->setText("Supprimer la facture");
+            ui->btnRemoveDoc->setIcon(QIcon(":icons/img/remove_bill"));
         } else {
             ui->btnEditDoc->setText("Éditer le devis");
             ui->btnEditDoc->setIcon(QIcon(":icons/img/add_quote"));
+            ui->btnRemoveDoc->setText("Supprimer le devis");
+            ui->btnRemoveDoc->setIcon(QIcon(":icons/img/remove_quote"));
         }
-
+        ui->btnRemoveDoc->setEnabled(true);
         ui->btnEditDoc->setEnabled(true);
         ui->btnLatex->setEnabled(true);
     } else {
         ui->btnEditDoc->setText("Éditer le document");
         ui->btnEditDoc->setIcon(QIcon(":icons/edit"));
         ui->btnEditDoc->setEnabled(false);
+        ui->btnRemoveDoc->setText("Supprimer le document");
+        ui->btnRemoveDoc->setIcon(QIcon(":icons/edit"));
+        ui->btnRemoveDoc->setEnabled(false);
         ui->btnLatex->setEnabled(false);
     }
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -298,7 +298,7 @@ void MainWindow::changeTree()
         ui->wdgCustomerData->printInformations(getCurrentCustomerId());
         ui->trCustomers->collapseAll();
         ui->trCustomers->expand(index);
-        changeProjectsTable();
+        customersTableToProjectsTable();
         ui->stackedWidget->setCurrentIndex(1);
         break;
     case 2:         // Project
@@ -341,6 +341,20 @@ void MainWindow::changeCustomerTable()
 }
 
 void MainWindow::changeProjectsTable()
+{
+    int row = ui->tblProjects->currentIndex().row();
+    QModelIndex index(ui->trCustomers->currentIndex());
+    if (treeLevel() == 2) {
+        while (index.parent().isValid())
+            index = ui->trCustomers->indexAbove(index);
+    }
+    for (int i = 0 ; i <= row ; ++i)
+        index = ui->trCustomers->indexBelow(index);
+    ui->trCustomers->setCurrentIndex(index);
+    updateBtn();
+}
+
+void MainWindow::customersTableToProjectsTable()
 {
     updateTableProjects(getCurrentCustomerId());
     ui->lblProjects->setText("<b>Projet(s) de: " + getCurrentCustomerName()+"</b>");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -334,9 +334,8 @@ void MainWindow::changeCustomerTable()
     ui->wdgCustomerData->printInformations(getCurrentCustomerId());
     int row = ui->tblCustomers->currentIndex().row();
     QModelIndex index(ui->trCustomers->indexAt(QPoint()));
-    for (int i = 0 ; i <= row ; ++i) {
+    for (int i = 0 ; i <= row ; ++i)
         index = ui->trCustomers->indexBelow(index);
-    }
     ui->trCustomers->setCurrentIndex(index);
     updateBtn();
 }
@@ -351,14 +350,17 @@ void MainWindow::changeProjectsTable()
     ui->tblProjects->setColumnWidth(3, 122);
     ui->tblProjects->setColumnWidth(4, 122);
     ui->stackedWidget->setCurrentIndex(1);
+    QModelIndex index(ui->trCustomers->currentIndex());
+    ui->trCustomers->expand(index);
     updateBtn();
 }
 
 void MainWindow::backToCustomersTable()
 {
     ui->stackedWidget->setCurrentIndex(0);
-    ui->actionNewQuote->setEnabled(false);
-    ui->actionNewBill->setEnabled(false);
+    ui->trCustomers->collapseAll();
+    changeCustomerTable();
+    updateBtn();
 }
 
 void MainWindow::backToProjectsTable()
@@ -375,17 +377,21 @@ void MainWindow::quotesProject()
 
 void MainWindow::updateBtn()
 {
-    if (ui->tblCustomers->currentIndex().row() > -1
+    if (ui->stackedWidget->currentIndex() == 0
+            && ui->tblCustomers->currentIndex().row() > -1
             && ui->tblCustomers->selectionModel()->hasSelection()) {
         ui->btnEdit->setEnabled(true);
         ui->btnDelCustomer->setEnabled(true);
-    } else {
+    } else if (ui->tblCustomers->currentIndex().row() == -1
+               && !ui->tblCustomers->selectionModel()->hasSelection()) {
         ui->btnEdit->setEnabled(false);
         ui->btnDelCustomer->setEnabled(false);
         ui->trCustomers->setCurrentIndex(ui->trCustomers->indexAt(QPoint()));
     }
 
-    if (ui->tblProjects->currentIndex().row() > -1
+    if ((ui->stackedWidget->currentIndex() == 1
+            || ui->stackedWidget->currentIndex() == 2)
+            && ui->tblProjects->currentIndex().row() > -1
             && ui->tblProjects->selectionModel()->hasSelection()) {
         ui->actionNewQuote->setEnabled(true);
         ui->actionNewBill->setEnabled(true);
@@ -396,8 +402,9 @@ void MainWindow::updateBtn()
         ui->actionNewBill->setEnabled(false);
     }
 
-    if (ui->tblQuotes->currentIndex().row() > -1
-        && ui->tblQuotes->selectionModel()->hasSelection()) {
+    if (ui->stackedWidget->currentIndex() == 2
+            && ui->tblQuotes->currentIndex().row() > -1
+            && ui->tblQuotes->selectionModel()->hasSelection()) {
         Billing b(getCurrentQuoteId());
         if (b.isBilling()) {
             ui->btnEditDoc->setText("Éditer la facture");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -237,6 +237,7 @@ void MainWindow::updateTree(QString filter)
 
 void MainWindow::newProject()
 {
+    QModelIndex indexTree = ui->trCustomers->currentIndex();
     QModelIndex index = ui->tblCustomers->currentIndex();
     AddProjectDialog *w;
     if(ui->stackedWidget->currentIndex() == 1) {
@@ -344,10 +345,18 @@ void MainWindow::changeProjectsTable()
 {
     int row = ui->tblProjects->currentIndex().row();
     QModelIndex index(ui->trCustomers->currentIndex());
-    if (treeLevel() == 2) {
-        while (index.parent().isValid())
-            index = ui->trCustomers->indexAbove(index);
-    }
+    if (treeLevel() == 2) index = findParent();
+    for (int i = 0 ; i <= row ; ++i)
+        index = ui->trCustomers->indexBelow(index);
+    ui->trCustomers->setCurrentIndex(index);
+    updateBtn();
+}
+
+void MainWindow::changeDocsTable()
+{
+    int row = ui->tblQuotes->currentIndex().row();
+    QModelIndex index(ui->trCustomers->currentIndex());
+    if (treeLevel() == 3) index = findParent();
     for (int i = 0 ; i <= row ; ++i)
         index = ui->trCustomers->indexBelow(index);
     ui->trCustomers->setCurrentIndex(index);
@@ -369,6 +378,34 @@ void MainWindow::customersTableToProjectsTable()
     updateBtn();
 }
 
+void MainWindow::projectsTableToDocsTable()
+{
+    ui->stackedWidget->setCurrentIndex(2);
+    updateTableBillings(getCurrentProjectId());
+    QModelIndex index(ui->trCustomers->currentIndex());
+    ui->trCustomers->expand(index);
+    updateBtn();
+}
+
+QModelIndex MainWindow::findParent() {
+    QModelIndex parent(ui->trCustomers->currentIndex());
+    switch (treeLevel()) {
+    case 2:
+        while (parent.parent().isValid())
+            parent = ui->trCustomers->indexAbove(parent);
+        break;
+    case 3:
+        while (parent.parent().parent().isValid())
+            parent = ui->trCustomers->indexAbove(parent);
+        break;
+    default:
+        parent = ui->trCustomers->indexAt(QPoint());
+        break;
+    }
+
+    return parent;
+}
+
 void MainWindow::backToCustomersTable()
 {
     ui->stackedWidget->setCurrentIndex(0);
@@ -380,13 +417,9 @@ void MainWindow::backToCustomersTable()
 void MainWindow::backToProjectsTable()
 {
     ui->stackedWidget->setCurrentIndex(1);
-}
-
-void MainWindow::quotesProject()
-{
-    ui->stackedWidget->setCurrentIndex(2);
-    updateTableBillings(getCurrentProjectId());
-    updateBtn();
+    QModelIndex index(ui->trCustomers->currentIndex());
+    if (treeLevel() != 2)  ui->trCustomers->collapse(index = findParent());
+    ui->trCustomers->setCurrentIndex(index);
 }
 
 void MainWindow::updateBtn()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -74,6 +74,7 @@ void MainWindow::addCustomer()
 {
     DialogAddCustomer addCustomerDialog;
     if (addCustomerDialog.exec()) { // accept
+        ui->stackedWidget->setCurrentIndex(0);
         updateTree();
         updateTableCustomers();
         updateBtn();
@@ -84,9 +85,6 @@ void MainWindow::addCustomer()
 void MainWindow::newProject()
 {
     QModelIndex index = ui->tblCustomers->currentIndex();
-    QModelIndex indexTree = ui->trCustomers->currentIndex();
-    if (treeLevel() == 2) indexTree = findParent();
-
     AddProjectDialog *addProjectDialog;
     if(ui->stackedWidget->currentIndex() == 1) {
         addProjectDialog = new AddProjectDialog(index.row(), 0, 0);
@@ -97,9 +95,9 @@ void MainWindow::newProject()
     if (addProjectDialog->exec()) {
         updateTree();
         updateTableProjects(getCurrentCustomerId());
+        changeCustomerTable();
+        ui->trCustomers->expand(ui->trCustomers->currentIndex());
     }
-    ui->trCustomers->setCurrentIndex(indexTree);
-    ui->trCustomers->expand(indexTree);
 }
 
 void MainWindow::addQuote()
@@ -118,13 +116,16 @@ void MainWindow::addDoc(bool isBilling)
     if (addDocDialog.exec()) {
         updateTableBillings(getCurrentProjectId());
         updateTree();
+        changeCustomerTable();
+        ui->trCustomers->expand(ui->trCustomers->currentIndex());
+        ui->stackedWidget->setCurrentIndex(1);
     }
 }
 
 void MainWindow::editCustomer() {
     DialogAddCustomer editCustomerDialog(getCurrentCustomerId());
     if (editCustomerDialog.exec()) {
-        updateTableCustomers("", ui->tblCustomers->currentIndex().row());
+        updateTableCustomers("");
         updateTree();
     }
 }
@@ -133,8 +134,10 @@ void MainWindow::editProject() {
     int row = ui->tblProjects->currentIndex().row();
     AddProjectDialog editProjectDialog(row, getCurrentProjectId());
     if (editProjectDialog.exec()) {
-        updateTableProjects(getCurrentCustomerId(), row);
+        updateTableProjects(getCurrentCustomerId());
         updateTree();
+        changeCustomerTable();
+        ui->trCustomers->expand(ui->trCustomers->currentIndex());
     }
 }
 
@@ -149,9 +152,13 @@ void MainWindow::editDoc()
                 false, getCurrentCustomerId(),getCurrentQuoteId());
 
     if (editDocDialog->exec()) {
-        updateTableBillings(getCurrentProjectId(),
-                            ui->tblQuotes->currentIndex().row());
+        updateTableBillings(getCurrentProjectId());
         updateTree();
+        changeCustomerTable();
+        ui->trCustomers->expand(ui->trCustomers->currentIndex());
+        changeProjectsTable();
+        ui->trCustomers->expand(ui->trCustomers->currentIndex());
+        //ui->stackedWidget->setCurrentIndex(1); // if we remove te project in bill return to projects list
     }
     delete editDocDialog;
 }
@@ -220,6 +227,7 @@ void MainWindow::updateTableBillings(const int idProject, const int row)
     ui->tblQuotes->setColumnWidth(2, 100);
     ui->tblQuotes->setColumnWidth(4, 150);
     if (row > -1) ui->tblQuotes->selectRow(row);
+    else ui->tblQuotes->clearSelection();
 }
 
 void MainWindow::editUser()
@@ -240,6 +248,7 @@ void MainWindow::updateTableCustomers(QString filter, const int row) {
     ui->tblCustomers->setColumnWidth(4, 150);
     ui->tblCustomers->setColumnWidth(5, 250);
     if (row > -1) ui->tblCustomers->selectRow(row);
+    else ui->tblCustomers->clearSelection();
 }
 
 void MainWindow::updateTableProjects(const int pId, const int row)
@@ -251,6 +260,7 @@ void MainWindow::updateTableProjects(const int pId, const int row)
     ui->tblProjects->setModel(Databases::ProjectDatabase::instance()->getProjectsTable(lastId));
     ui->tblProjects->hideColumn(0);
     if (row > -1) ui->tblProjects->selectRow(row);
+    else ui->tblProjects->clearSelection();
 }
 
 void MainWindow::updateTree(QString filter)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -141,39 +141,38 @@ void MainWindow::removeProject() {
 }
 
 void MainWindow::removeDoc() {
-
+    removeItem(ui->tblQuotes, ItemType(ItemType::BILLING, "document"));
 }
 
 void MainWindow::removeItem(QTableView *tbl, ItemType itemType)
 {
-    if (tbl->selectionModel()->hasSelection()) {
-
-        if (QMessageBox::warning(
-                    this,
-                    "Suppression d'"+ QString((itemType.getType() == ItemType::BILLING ? "une " : "un ")) + itemType.getName(),
-                    "Voulez vous supprimer " +
-                    (itemType.getType() == ItemType::BILLING ?
-                            "la " +itemType.getName()+" séléctionnée" :
-                            "le "+itemType.getName()+" sélectionné") + " ?",
-                    "Supprimer",
-                    "Annuler") == 0)
-        {
-            QModelIndex ls = tbl->selectionModel()->selectedRows().first();
-            int pid = tbl->model()->data(ls,Qt::DisplayRole).toInt();
-            itemType.getModel(pid)->remove();
-            switch(itemType.getType()) {
-            case ItemType::CUSTOMER:
-                updateTableCustomers();
-                break;
-            case ItemType::PROJECT:
-                updateTableProjects();
-                break;
-            case ItemType::BILLING:
-                break;
-            }
-
-            updateTree();
+    if (QMessageBox::warning(
+                this,
+                "Suppression d'"+ QString((itemType.getType() == ItemType::BILLING ? "une " : "un ")) + itemType.getName(),
+                "Voulez vous supprimer " +
+                (itemType.getType() == ItemType::BILLING ?
+                        "la " +itemType.getName()+" séléctionnée" :
+                        "le "+itemType.getName()+" sélectionné") + " ?",
+                "Supprimer",
+                "Annuler") == 0)
+    {
+        QModelIndex ls = tbl->selectionModel()->selectedRows().first();
+        int pid = tbl->model()->data(ls,Qt::DisplayRole).toInt();
+        itemType.getModel(pid)->remove();
+        switch(itemType.getType()) {
+        case ItemType::CUSTOMER:
+            updateTableCustomers();
+            break;
+        case ItemType::PROJECT:
+            updateTableProjects();
+            break;
+        case ItemType::BILLING:
+            updateTableBillings(getCurrentProjectId());
+            break;
         }
+
+        updateTree();
+        updateBtn();
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -140,6 +140,10 @@ void MainWindow::removeProject() {
     removeItem(ui->tblProjects, ItemType(ItemType::PROJECT, "projet"));
 }
 
+void MainWindow::removeDoc() {
+
+}
+
 void MainWindow::removeItem(QTableView *tbl, ItemType itemType)
 {
     if (tbl->selectionModel()->hasSelection()) {
@@ -477,9 +481,4 @@ void MainWindow::openContextualMenuTree(const QPoint point)
     menu->exec(ui->trCustomers->mapToGlobal(buffPoint));
 
 }
-}
-
-void Gui::MainWindow::on_chkProjectName_clicked(bool checked)
-{
-
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -171,10 +171,16 @@ void MainWindow::removeCustomer() {
 
 void MainWindow::removeProject() {
     removeItem(ui->tblProjects, ItemType(ItemType::PROJECT, "projet"));
+    changeCustomerTable();
+    ui->trCustomers->expand(ui->trCustomers->currentIndex());
 }
 
 void MainWindow::removeDoc() {
     removeItem(ui->tblQuotes, ItemType(ItemType::BILLING, "document"));
+    changeCustomerTable();
+    ui->trCustomers->expand(ui->trCustomers->currentIndex());
+    changeProjectsTable();
+    ui->trCustomers->expand(ui->trCustomers->currentIndex());
 }
 
 void MainWindow::removeItem(QTableView *tbl, ItemType itemType)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -200,6 +200,11 @@ private slots:
      */
     void changeProjectsTable();
     /**
+     * @brief MainWindow::changeDocsTable function to update the view
+     * when we change the selected doc in tblQuotes
+     */
+    void changeDocsTable();
+    /**
      * @brief MainWindow::customersTableToProjectsTable changes projects with the <i>index</i>
      * of the customer in table of customers
      */
@@ -213,10 +218,15 @@ private slots:
      */
     void backToProjectsTable();
     /**
-     * @brief MainWindow::quotesProject displays quotes of a project with the <i>index</i>
+     * @brief MainWindow::projectsTableToDocsTable displays quotes of a project with the <i>index</i>
      * of the project in the table of projects
      */
-    void quotesProject();
+    void projectsTableToDocsTable();
+    /**
+     * @brief MainWindow::findParent return the parent of an item in tree
+     * @return QModelIndex
+     */
+    QModelIndex findParent();
 
 private:
     /**

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -85,6 +85,11 @@ public:
      */
     int treeLevel();
     /**
+     * @brief MainWindow::rootTree return the root of the tree "Tous les clients"
+     * @return QModelIndex
+     */
+    QModelIndex rootTree();
+    /**
      * @brief MainWindow::addDoc open window to add a new document
      * @param bool quote or bill
      * @see addBill addQuote

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -190,14 +190,20 @@ private slots:
      */
     void changeTree();
     /**
-     * @brief MainWindow::changeCustomerTable calls changeCustomerTable
+     * @brief MainWindow::changeCustomerTable function to update the view
+     * when we change the selected customer in tblCustomers
      */
     void changeCustomerTable();
     /**
-     * @brief MainWindow::changeProjectsTable changes projects with the <i>index</i>
-     * of the customer in table of customers
+     * @brief MainWindow::changeProjectsTable function to update the view
+     * when we change the selected project in tblProjects
      */
     void changeProjectsTable();
+    /**
+     * @brief MainWindow::customersTableToProjectsTable changes projects with the <i>index</i>
+     * of the customer in table of customers
+     */
+    void customersTableToProjectsTable();
     /**
      * @brief MainWindow::backToCustomersTable displays the customers table
      */

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -167,6 +167,10 @@ public slots:
      * @brief MainWindow::editDoc Edit the quote or bill of the project
      */
     void editDoc();
+    /**
+     * @brief MainWindow::removeDoc Remove the quote or bill of the project
+     */
+    void removeDoc();
 
 private slots:
     /**
@@ -207,8 +211,6 @@ private slots:
      * of the project in the table of projects
      */
     void quotesProject();
-
-    void on_chkProjectName_clicked(bool checked);
 
 private:
     /**

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -22,7 +22,7 @@
     <item row="0" column="0">
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>1</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="page">
        <layout class="QGridLayout" name="gridLayout_3">
@@ -1042,7 +1042,7 @@ border: 1px solid #bbb;</string>
    <sender>tblProjects</sender>
    <signal>doubleClicked(QModelIndex)</signal>
    <receiver>MainWindow</receiver>
-   <slot>quotesProject()</slot>
+   <slot>projectsTableToDocsTable()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>392</x>
@@ -1202,7 +1202,7 @@ border: 1px solid #bbb;</string>
    <sender>tblQuotes</sender>
    <signal>clicked(QModelIndex)</signal>
    <receiver>MainWindow</receiver>
-   <slot>updateBtn()</slot>
+   <slot>changeDocsTable()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>698</x>
@@ -1441,7 +1441,7 @@ border: 1px solid #bbb;</string>
   <slot>backToCustomersTable()</slot>
   <slot>addQuote()</slot>
   <slot>projectsCustomersTableTree()</slot>
-  <slot>quotesProject()</slot>
+  <slot>projectsTableToDocsTable()</slot>
   <slot>backToProjectsTable()</slot>
   <slot>editProject()</slot>
   <slot>removeProject()</slot>
@@ -1452,5 +1452,6 @@ border: 1px solid #bbb;</string>
   <slot>editDoc()</slot>
   <slot>removeDoc()</slot>
   <slot>changeProjectsTable()</slot>
+  <slot>changeDocsTable()</slot>
  </slots>
 </ui>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -789,8 +789,8 @@ border: 1px solid #bbb;</string>
    <slot>editCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>902</x>
-     <y>539</y>
+     <x>371</x>
+     <y>117</y>
     </hint>
     <hint type="destinationlabel">
      <x>764</x>
@@ -805,8 +805,8 @@ border: 1px solid #bbb;</string>
    <slot>removeCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>784</x>
-     <y>539</y>
+     <x>356</x>
+     <y>117</y>
     </hint>
     <hint type="destinationlabel">
      <x>280</x>
@@ -853,8 +853,8 @@ border: 1px solid #bbb;</string>
    <slot>addCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>355</x>
-     <y>519</y>
+     <x>326</x>
+     <y>117</y>
     </hint>
     <hint type="destinationlabel">
      <x>406</x>
@@ -869,8 +869,8 @@ border: 1px solid #bbb;</string>
    <slot>newProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>656</x>
-     <y>539</y>
+     <x>341</x>
+     <y>117</y>
     </hint>
     <hint type="destinationlabel">
      <x>720</x>
@@ -997,8 +997,8 @@ border: 1px solid #bbb;</string>
    <slot>changeProjectsTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>672</x>
-     <y>193</y>
+     <x>379</x>
+     <y>106</y>
     </hint>
     <hint type="destinationlabel">
      <x>1026</x>
@@ -1008,13 +1008,13 @@ border: 1px solid #bbb;</string>
   </connection>
   <connection>
    <sender>btnBackToCustomers</sender>
-   <signal>clicked()</signal>
+   <signal>released()</signal>
    <receiver>MainWindow</receiver>
    <slot>backToCustomersTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>472</x>
-     <y>133</y>
+     <x>336</x>
+     <y>106</y>
     </hint>
     <hint type="destinationlabel">
      <x>326</x>
@@ -1045,8 +1045,8 @@ border: 1px solid #bbb;</string>
    <slot>quotesProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>697</x>
-     <y>263</y>
+     <x>380</x>
+     <y>112</y>
     </hint>
     <hint type="destinationlabel">
      <x>920</x>
@@ -1056,7 +1056,7 @@ border: 1px solid #bbb;</string>
   </connection>
   <connection>
    <sender>btnBackToProjects</sender>
-   <signal>clicked()</signal>
+   <signal>released()</signal>
    <receiver>MainWindow</receiver>
    <slot>backToProjectsTable()</slot>
    <hints>
@@ -1077,8 +1077,8 @@ border: 1px solid #bbb;</string>
    <slot>newProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>910</x>
-     <y>538</y>
+     <x>515</x>
+     <y>144</y>
     </hint>
     <hint type="destinationlabel">
      <x>797</x>
@@ -1093,8 +1093,8 @@ border: 1px solid #bbb;</string>
    <slot>editProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>910</x>
-     <y>538</y>
+     <x>515</x>
+     <y>144</y>
     </hint>
     <hint type="destinationlabel">
      <x>738</x>
@@ -1109,8 +1109,8 @@ border: 1px solid #bbb;</string>
    <slot>removeProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>910</x>
-     <y>538</y>
+     <x>515</x>
+     <y>144</y>
     </hint>
     <hint type="destinationlabel">
      <x>0</x>
@@ -1141,8 +1141,8 @@ border: 1px solid #bbb;</string>
    <slot>changeCustomerTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>672</x>
-     <y>193</y>
+     <x>379</x>
+     <y>106</y>
     </hint>
     <hint type="destinationlabel">
      <x>415</x>
@@ -1157,8 +1157,8 @@ border: 1px solid #bbb;</string>
    <slot>updateBtn()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>697</x>
-     <y>263</y>
+     <x>380</x>
+     <y>112</y>
     </hint>
     <hint type="destinationlabel">
      <x>0</x>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -589,6 +589,9 @@ border: 1px solid #bbb;</string>
        <property name="expandsOnDoubleClick">
         <bool>false</bool>
        </property>
+       <attribute name="headerVisible">
+        <bool>false</bool>
+       </attribute>
       </widget>
      </item>
     </layout>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -22,7 +22,7 @@
     <item row="0" column="0">
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="page">
        <layout class="QGridLayout" name="gridLayout_3">
@@ -289,6 +289,17 @@
              <widget class="QPushButton" name="btnEditDoc">
               <property name="text">
                <string>Éditer le document</string>
+              </property>
+              <property name="icon">
+               <iconset resource="icons.qrc">
+                <normaloff>:/icons/edit</normaloff>:/icons/edit</iconset>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btnRemoveDoc">
+              <property name="text">
+               <string>Supprimer le document</string>
               </property>
               <property name="icon">
                <iconset resource="icons.qrc">
@@ -775,8 +786,8 @@ border: 1px solid #bbb;</string>
    <slot>editCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>372</x>
-     <y>106</y>
+     <x>902</x>
+     <y>539</y>
     </hint>
     <hint type="destinationlabel">
      <x>764</x>
@@ -791,8 +802,8 @@ border: 1px solid #bbb;</string>
    <slot>removeCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>353</x>
-     <y>106</y>
+     <x>784</x>
+     <y>539</y>
     </hint>
     <hint type="destinationlabel">
      <x>280</x>
@@ -855,8 +866,8 @@ border: 1px solid #bbb;</string>
    <slot>newProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>335</x>
-     <y>106</y>
+     <x>656</x>
+     <y>539</y>
     </hint>
     <hint type="destinationlabel">
      <x>720</x>
@@ -983,8 +994,8 @@ border: 1px solid #bbb;</string>
    <slot>changeProjectsTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>378</x>
-     <y>98</y>
+     <x>672</x>
+     <y>193</y>
     </hint>
     <hint type="destinationlabel">
      <x>1026</x>
@@ -999,8 +1010,8 @@ border: 1px solid #bbb;</string>
    <slot>backToCustomersTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>332</x>
-     <y>95</y>
+     <x>472</x>
+     <y>133</y>
     </hint>
     <hint type="destinationlabel">
      <x>326</x>
@@ -1031,8 +1042,8 @@ border: 1px solid #bbb;</string>
    <slot>quotesProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>392</x>
-     <y>123</y>
+     <x>697</x>
+     <y>263</y>
     </hint>
     <hint type="destinationlabel">
      <x>920</x>
@@ -1047,8 +1058,8 @@ border: 1px solid #bbb;</string>
    <slot>backToProjectsTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>392</x>
-     <y>123</y>
+     <x>657</x>
+     <y>138</y>
     </hint>
     <hint type="destinationlabel">
      <x>672</x>
@@ -1063,8 +1074,8 @@ border: 1px solid #bbb;</string>
    <slot>newProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>492</x>
-     <y>123</y>
+     <x>910</x>
+     <y>538</y>
     </hint>
     <hint type="destinationlabel">
      <x>797</x>
@@ -1079,8 +1090,8 @@ border: 1px solid #bbb;</string>
    <slot>editProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>492</x>
-     <y>123</y>
+     <x>910</x>
+     <y>538</y>
     </hint>
     <hint type="destinationlabel">
      <x>738</x>
@@ -1095,8 +1106,8 @@ border: 1px solid #bbb;</string>
    <slot>removeProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>492</x>
-     <y>123</y>
+     <x>910</x>
+     <y>538</y>
     </hint>
     <hint type="destinationlabel">
      <x>0</x>
@@ -1127,8 +1138,8 @@ border: 1px solid #bbb;</string>
    <slot>changeCustomerTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>378</x>
-     <y>98</y>
+     <x>672</x>
+     <y>193</y>
     </hint>
     <hint type="destinationlabel">
      <x>415</x>
@@ -1143,8 +1154,8 @@ border: 1px solid #bbb;</string>
    <slot>updateBtn()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>392</x>
-     <y>123</y>
+     <x>697</x>
+     <y>263</y>
     </hint>
     <hint type="destinationlabel">
      <x>0</x>
@@ -1191,8 +1202,8 @@ border: 1px solid #bbb;</string>
    <slot>updateBtn()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>392</x>
-     <y>123</y>
+     <x>698</x>
+     <y>274</y>
     </hint>
     <hint type="destinationlabel">
      <x>502</x>
@@ -1208,7 +1219,7 @@ border: 1px solid #bbb;</string>
    <hints>
     <hint type="sourcelabel">
      <x>17</x>
-     <y>148</y>
+     <y>258</y>
     </hint>
     <hint type="destinationlabel">
      <x>74</x>
@@ -1224,11 +1235,11 @@ border: 1px solid #bbb;</string>
    <hints>
     <hint type="sourcelabel">
      <x>34</x>
-     <y>145</y>
+     <y>255</y>
     </hint>
     <hint type="destinationlabel">
-     <x>55</x>
-     <y>178</y>
+     <x>68</x>
+     <y>198</y>
     </hint>
    </hints>
   </connection>
@@ -1240,7 +1251,7 @@ border: 1px solid #bbb;</string>
    <hints>
     <hint type="sourcelabel">
      <x>86</x>
-     <y>148</y>
+     <y>258</y>
     </hint>
     <hint type="destinationlabel">
      <x>102</x>
@@ -1256,11 +1267,11 @@ border: 1px solid #bbb;</string>
    <hints>
     <hint type="sourcelabel">
      <x>76</x>
-     <y>145</y>
+     <y>255</y>
     </hint>
     <hint type="destinationlabel">
-     <x>102</x>
-     <y>240</y>
+     <x>115</x>
+     <y>261</y>
     </hint>
    </hints>
   </connection>
@@ -1272,7 +1283,7 @@ border: 1px solid #bbb;</string>
    <hints>
     <hint type="sourcelabel">
      <x>97</x>
-     <y>146</y>
+     <y>256</y>
     </hint>
     <hint type="destinationlabel">
      <x>150</x>
@@ -1307,8 +1318,8 @@ border: 1px solid #bbb;</string>
      <y>211</y>
     </hint>
     <hint type="destinationlabel">
-     <x>139</x>
-     <y>175</y>
+     <x>152</x>
+     <y>198</y>
     </hint>
    </hints>
   </connection>
@@ -1323,8 +1334,8 @@ border: 1px solid #bbb;</string>
      <y>211</y>
     </hint>
     <hint type="destinationlabel">
-     <x>139</x>
-     <y>198</y>
+     <x>152</x>
+     <y>219</y>
     </hint>
    </hints>
   </connection>
@@ -1383,12 +1394,28 @@ border: 1px solid #bbb;</string>
    <slot>editDoc()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>392</x>
-     <y>123</y>
+     <x>528</x>
+     <y>538</y>
     </hint>
     <hint type="destinationlabel">
      <x>319</x>
      <y>563</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>btnRemoveDoc</sender>
+   <signal>released()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>removeDoc()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>618</x>
+     <y>529</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>609</x>
+     <y>558</y>
     </hint>
    </hints>
   </connection>
@@ -1420,5 +1447,6 @@ border: 1px solid #bbb;</string>
   <slot>updateBtn()</slot>
   <slot>addBill()</slot>
   <slot>editDoc()</slot>
+  <slot>removeDoc()</slot>
  </slots>
 </ui>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -22,7 +22,7 @@
     <item row="0" column="0">
      <widget class="QStackedWidget" name="stackedWidget">
       <property name="currentIndex">
-       <number>2</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="page">
        <layout class="QGridLayout" name="gridLayout_3">
@@ -789,8 +789,8 @@ border: 1px solid #bbb;</string>
    <slot>editCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>371</x>
-     <y>117</y>
+     <x>853</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
      <x>764</x>
@@ -805,8 +805,8 @@ border: 1px solid #bbb;</string>
    <slot>removeCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>356</x>
-     <y>117</y>
+     <x>710</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
      <x>280</x>
@@ -853,8 +853,8 @@ border: 1px solid #bbb;</string>
    <slot>addCustomer()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>326</x>
-     <y>117</y>
+     <x>366</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
      <x>406</x>
@@ -869,8 +869,8 @@ border: 1px solid #bbb;</string>
    <slot>newProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>341</x>
-     <y>117</y>
+     <x>537</x>
+     <y>519</y>
     </hint>
     <hint type="destinationlabel">
      <x>720</x>
@@ -994,11 +994,11 @@ border: 1px solid #bbb;</string>
    <sender>tblCustomers</sender>
    <signal>doubleClicked(QModelIndex)</signal>
    <receiver>MainWindow</receiver>
-   <slot>changeProjectsTable()</slot>
+   <slot>customersTableToProjectsTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>379</x>
-     <y>106</y>
+     <x>380</x>
+     <y>107</y>
     </hint>
     <hint type="destinationlabel">
      <x>1026</x>
@@ -1045,8 +1045,8 @@ border: 1px solid #bbb;</string>
    <slot>quotesProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>380</x>
-     <y>112</y>
+     <x>392</x>
+     <y>158</y>
     </hint>
     <hint type="destinationlabel">
      <x>920</x>
@@ -1077,8 +1077,8 @@ border: 1px solid #bbb;</string>
    <slot>newProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>515</x>
-     <y>144</y>
+     <x>910</x>
+     <y>538</y>
     </hint>
     <hint type="destinationlabel">
      <x>797</x>
@@ -1093,8 +1093,8 @@ border: 1px solid #bbb;</string>
    <slot>editProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>515</x>
-     <y>144</y>
+     <x>910</x>
+     <y>538</y>
     </hint>
     <hint type="destinationlabel">
      <x>738</x>
@@ -1109,8 +1109,8 @@ border: 1px solid #bbb;</string>
    <slot>removeProject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>515</x>
-     <y>144</y>
+     <x>910</x>
+     <y>538</y>
     </hint>
     <hint type="destinationlabel">
      <x>0</x>
@@ -1141,8 +1141,8 @@ border: 1px solid #bbb;</string>
    <slot>changeCustomerTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>379</x>
-     <y>106</y>
+     <x>380</x>
+     <y>107</y>
     </hint>
     <hint type="destinationlabel">
      <x>415</x>
@@ -1154,11 +1154,11 @@ border: 1px solid #bbb;</string>
    <sender>tblProjects</sender>
    <signal>clicked(QModelIndex)</signal>
    <receiver>MainWindow</receiver>
-   <slot>updateBtn()</slot>
+   <slot>changeProjectsTable()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>380</x>
-     <y>112</y>
+     <x>392</x>
+     <y>158</y>
     </hint>
     <hint type="destinationlabel">
      <x>0</x>
@@ -1437,7 +1437,7 @@ border: 1px solid #bbb;</string>
   <slot>aboutIcons()</slot>
   <slot>changeCustomer()</slot>
   <slot>openProjects()</slot>
-  <slot>changeProjectsTable()</slot>
+  <slot>customersTableToProjectsTable()</slot>
   <slot>backToCustomersTable()</slot>
   <slot>addQuote()</slot>
   <slot>projectsCustomersTableTree()</slot>
@@ -1451,5 +1451,6 @@ border: 1px solid #bbb;</string>
   <slot>addBill()</slot>
   <slot>editDoc()</slot>
   <slot>removeDoc()</slot>
+  <slot>changeProjectsTable()</slot>
  </slots>
 </ui>


### PR DESCRIPTION
Bon l'ajout de la suppression n'était pas compliqué, j'en ait profité pour implémenter une fonctionnalité supplémentaire que me tenait à coeur...

TADA ! Et oui l'arbre se met automatiquement à jour en fonction des sélections dans le tableau, des changement de tableaux etc, si on clic sur un client dans le tableau il sera automatiquement sélectionné dans l'arbre, si on est dans le tableaux des projets, l'arbre sera automatiquement étendu jusqu'au projet correspondant.
Cela implique beaucoup de changements du côté de mainWindow, je ne pense pas qu'il soit vraiment utile de refactoriser au max pour rendre plus beau et plus compréhensible ce côté même si je pense dans le fond que sur le principe on aurait peut être pu gérer les relations sur l'arbre autre part.

Bref, bonne relecture et faites moi signe quand je peux merger.

(Oui je me suis dit qu'une relation à sens unique ça ne pouvait pas marché alors quand c'est dans les deux sens mon couple tableau/arbre ne pourra aller que de l'avant =P)