### PR TITLE
Fix bug to open PDF

### DIFF
--- a/src/gui/mainwindow/mainwindow.cpp
+++ b/src/gui/mainwindow/mainwindow.cpp
@@ -84,7 +84,7 @@ void MainWindow::addCustomer()
     if (DialogAddCustomer().exec()) { // accept
         ui->stackedWidget->setCurrentIndex(0);
         updateTableCustomers();
-        updateTree();
+        updateTree();        
     }
 }
 
@@ -99,6 +99,7 @@ void MainWindow::addProject()
         updateTableProjects(getCurrentCustomerId());
         updateTree();
         changeCustomerTable();
+        User(1).updateFolders();
         ui->trCustomers->expand(ui->trCustomers->currentIndex());
     }
 }
@@ -110,7 +111,6 @@ void MainWindow::addQuote() {
 void MainWindow::addBill()
 {
     addDoc(true);
-
 }
 
 void MainWindow::addDoc(bool isBilling) {

--- a/src/models/billing.cpp
+++ b/src/models/billing.cpp
@@ -104,19 +104,15 @@ void Billing::generatePdf()
 }
 
 QString Billing::getFolder() {
-    QString s,fact;
+    QString fact;
 
     if (isBilling()) {
-        s = "Facture";
         fact = "Factures";
-    }
-    else {
-        s = "Devis";
+    } else {
         fact ="Devis";
     }
-
-    return _contributories.getCustomer()->getPath()
-            +"/"+fact;
+    qDebug() << _contributories.getCustomer()->getPath() + "/" + fact;
+    return _contributories.getCustomer()->getPath() + "/" + fact;
 }
 QString Billing::getPath() {
     return getFolder()+"/"+getFilename();

--- a/src/models/billing.cpp
+++ b/src/models/billing.cpp
@@ -111,7 +111,7 @@ QString Billing::getFolder() {
     } else {
         fact ="Devis";
     }
-    qDebug() << _contributories.getCustomer()->getPath() + "/" + fact;
+
     return _contributories.getCustomer()->getPath() + "/" + fact;
 }
 QString Billing::getPath() {

--- a/src/models/user.cpp
+++ b/src/models/user.cpp
@@ -47,12 +47,12 @@ QVariantHash User::getDataMap()
 void User::updateFolders()
 {
     Customer customer;
-    Project p1;
-    Project p2;
     QString path;
     QString folder;
     QDir directory;
     Utils::HierarchicalSystem hierarchy;
+
+    hierarchy.updateData();
 
     path = getWorkspacePath();
     folder = getWorkspaceName();
@@ -68,26 +68,14 @@ void User::updateFolders()
 
         path = Utils::Directories::makeDirectory(directory, path, folder);
 
-        for (auto p = hierarchy.getProjects().cbegin();
-             p != hierarchy.getProjects().cend();
-             ++p ) {
-            p1 = *p.value();
-            p2 = *c.key();
+        path  = Utils::Directories::makeDirectory(directory, path, "Devis");
+        path = customer.getPath();
+        directory.setPath(path);
 
-            if (p1 == p2) {
-                if ((*p.key()).isBilling()) {
-                    folder = "Factures";
-                } else {
-                    folder = "Devis";
-                }
-                path  = Utils::Directories::makeDirectory(directory,
-                                                          path,
-                                                          folder);
-            }
+        path  = Utils::Directories::makeDirectory(directory, path, "Factures");
+        path = customer.getPath();
+        directory.setPath(path);
 
-            path = customer.getPath();
-            directory.setPath(path);
-        }
         path = getWorkspacePath() + "/" + getWorkspaceName();
         directory.setPath(path);
     }


### PR DESCRIPTION
Avant lorsqu'on créer un nouveau client, on ne pouvait pas afficher son PDF.
La raison était qu'aucun dossier n'était créer lorsqu'on créer un nouveau client, du coup il n'arrivait pas à trouvé le "path". Lorsqu'on on créer un nouveau Projet à un nouveau client, un dossier est alors créé.
