### PR TITLE
QSettings : debug or release in case for two configurations

### DIFF
--- a/src/database/accessdatabase.cpp
+++ b/src/database/accessdatabase.cpp
@@ -17,7 +17,15 @@ AccessDatabase::AccessDatabase()
 
 void AccessDatabase::init()
 {
-    QSettings settings("FACT Team", "FactDev");
+    QString environment;
+#if QT_NO_DEBUG
+    environment = "release";
+#else
+    environment = "debug";
+#endif
+
+    QSettings settings("FACT Team", "FactDev-"+environment);
+
     if(!settings.value("externalDbExists", false).toBool()) {
         _exists = false;
     } else {
@@ -33,7 +41,15 @@ void AccessDatabase::init()
 
 void AccessDatabase::commit()
 {
-    QSettings settings("FACT Team", "FactDev");
+    QString environment;
+
+#if QT_NO_DEBUG
+    environment = "release";
+#else
+    environment = "debug";
+#endif
+
+    QSettings settings("FACT Team", "FactDev-"+environment);
     settings.setValue("externalDbExists", _exists);
     settings.setValue("address", _address);
     settings.setValue("port", _port);

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -72,10 +72,17 @@ void Database::changeDatabase(DbType dbType)
 void Database::open() {
     mDatabase = QSqlDatabase::database();
     bool creerStructure = false;
+    QString environment;
+
+#if QT_NO_DEBUG
+    environment = "release";
+#else
+    environment = "debug";
+#endif
 
     if(!AccessDatabase::_exists || AccessDatabase::_dbType == SQLITE)
     {
-        _settings = new QSettings("FACT", "FactDev");
+        _settings = new QSettings("FACT", "FactDev-"+environment);
         _settings->setValue("dbPath", QCoreApplication::applicationDirPath());
         _isMysql = false;
         if(!QFile::exists(

--- a/src/gui/mainwindow/mainwindow.cpp
+++ b/src/gui/mainwindow/mainwindow.cpp
@@ -12,7 +12,16 @@ MainWindow::MainWindow(QWidget *parent) :
 {
     setupUi();
     setupSignalsSlots();
-    QSettings settings("FACT Team", "FactDev");
+
+    QString environment;
+
+#if QT_NO_DEBUG
+    environment = "release";
+#else
+    environment = "debug";
+#endif
+
+    QSettings settings("FACT Team", "FactDev-"+environment);
     Databases::AccessDatabase::init();
     if(!Databases::AccessDatabase::_exists/* | !QFile(settings.value("dbPath").toString()+"/"+Parameters::DB_FILENAME).exists()*/) {
         StartedWindowsDialog w;

--- a/src/utils/log.cpp
+++ b/src/utils/log.cpp
@@ -6,7 +6,7 @@ Log* Log::_instance = 0;
 TypeLog Log::_type = INFO;
 
 Log::Log() {
-    QSettings settings("FactDev", "FACT");
+
     _file = new QFile(
                 QCoreApplication::applicationDirPath()+"/"+"/message.log");
     bool exists = _file->exists();

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -5,7 +5,6 @@
 #include <QCoreApplication>
 #include <QTextStream>
 #include <QDebug>
-#include <QSettings>
 #include <QString>
 
 #include "parameters.h"

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -46,6 +46,7 @@ int mysqlExecution(int argc, char**argv)
     std::cout << "=== Execution des tests de FactDev v" << QString::number(Parameters::VERSION).toStdString() << " avec MySQL ===" << std::endl;
 
     if(argc >= 3) {
+        Databases::AccessDatabase::init();
         Databases::AccessDatabase::_address = argv[1];
         Databases::AccessDatabase::_userDb = argv[2];
         Databases::AccessDatabase::_password = argv[3];


### PR DESCRIPTION
Et hpo : 
- Si on est en mode debug on utilise le fichier de conf FactDev-debug, sinon FactDev-release : ça permet de ne pas pourrir les données de tests si je me sers de FactDev en prod :) 