### PR TITLE
Bug de l'ajout d'un projet

### DIFF
--- a/src/database/customerdatabase.cpp
+++ b/src/database/customerdatabase.cpp
@@ -47,7 +47,9 @@ WdgModels::CustomersTableModel*
 
     while(q.next()) {
         Customer c = *getCustomer(q);
-        ret->append(c);
+        if(!c.isArchived()) {
+            ret->append(c);
+        }
     }
 
     return ret;

--- a/src/gui/dialogs/addprojectdialog.cpp
+++ b/src/gui/dialogs/addprojectdialog.cpp
@@ -29,7 +29,6 @@ AddProjectDialog::~AddProjectDialog()
 }
 
 void AddProjectDialog::accept() {
-
     _project.setName(ui->leNameProject->text());
     _project.setDescription(ui->leDescription->toPlainText());
     _project.setBeginDate(QDate::currentDate());

--- a/src/gui/mainwindow/mainwindow.cpp
+++ b/src/gui/mainwindow/mainwindow.cpp
@@ -115,9 +115,7 @@ void MainWindow::addCustomer()
 void MainWindow::addProject()
 {
     AddProjectDialog *addProjectDialog =
-            ui->stackedWidget->currentIndex() == 1 ?
-                new AddProjectDialog(0, ui->tblCustomers->currentIndex().row())
-              : new AddProjectDialog();
+                new AddProjectDialog(0, ui->tblCustomers->currentIndex().row());
 
     if (addProjectDialog->exec()) {
         updateTableProjects(getCurrentCustomerId());


### PR DESCRIPTION
Lorsqu'on ajoutait un projet depuis la page 0 ou 2 du stackWidget, la pré-sélection du client lors de l'ajout d'un nouveau projet ne fonctionnait pas (sélectionnait le premier client de la liste).

C'est maintenant corrigé.

J'ai au passage vu une petite erreur : la fenêtre d'ajout d'un projet contenait **tous** le clients, même ceux archivés.